### PR TITLE
Add hash router capability to router.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "bundle": "rollup -i src/index.js -o dist/router.js -f umd -mn router",
     "minify": "uglifyjs dist/router.js -o dist/router.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --source-map dist/router.js.map",
     "prepublish": "npm run build",
-    "format": "prettier --semi false --write 'src/**/*.js'",
+    "format": "prettier --semi false --write '{src,test}/**/*.js'",
     "release": "npm run build && npm test && git commit -am $npm_package_version && git tag $npm_package_version && git push && git push --tags && npm publish"
   },
   "babel": {
@@ -39,6 +39,7 @@
     "babel-preset-es2015": "^6.24.1",
     "hyperapp": "^0.12.0",
     "jest": "^20.0.4",
+    "jest-cli": "^20.0.4",
     "prettier": "~1.5.3",
     "rollup": "^0.47.6",
     "uglify-js": "^2.7.5"

--- a/src/router.js
+++ b/src/router.js
@@ -25,7 +25,8 @@ export function router(options) {
             }
           },
           go: function(state, actions, path) {
-            if (getLocation() !== path) { // TODO: what about location.search?
+            if (getLocation() !== path) {
+              // TODO: what about location.search?
               if (options.hash) location.hash = path
               else history.pushState({}, "", path)
               actions.router.set({

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -10,6 +10,7 @@ Object.defineProperty(window.location, "pathname", {
 beforeEach(() => {
   document.body.innerHTML = ""
   location.pathname = "/"
+  location.hash = ""
   history.pushState = function(state, title, url) {
     location.pathname = url
   }
@@ -404,3 +405,134 @@ test("fire route only if path changes", done => {
   })
 })
 
+test("{ hash: true }", done => {
+  app({
+    view: [
+      [
+        "/",
+        () =>
+          h(
+            "div",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<div>foo</div>`)
+                done()
+              }
+            },
+            "foo"
+          )
+      ]
+    ],
+    mixins: [router({ hash: true })]
+  })
+})
+
+test("#/ ({ hash: true })", done => {
+  location.hash = "#/"
+  app({
+    view: [
+      [
+        "/",
+        () =>
+          h(
+            "div",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<div>foo</div>`)
+                done()
+              }
+            },
+            "foo"
+          )
+      ]
+    ],
+    mixins: [router({ hash: true })]
+  })
+})
+
+test("#/about ({ hash: true })", done => {
+  location.hash = "#/about"
+  app({
+    view: [
+      ["/", () => h("div", "foo")],
+      [
+        "/about",
+        () =>
+          h(
+            "div",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<div>bar</div>`)
+                done()
+              }
+            },
+            "bar"
+          )
+      ]
+    ],
+    mixins: [router({ hash: true })]
+  })
+})
+
+test("go ({ hash: true })", done => {
+  app({
+    view: [
+      [
+        "/",
+        (state, actions) =>
+          h("div", {
+            oncreate() {
+              expect(document.body.innerHTML).toBe("<div></div>")
+              actions.router.go("/foo")
+            }
+          })
+      ],
+      [
+        "/foo",
+        (state, actions) =>
+          h(
+            "div",
+            {
+              onupdate() {
+                expect(location.hash).toBe("#/foo")
+                expect(document.body.innerHTML).toBe("<div>foo</div>")
+                actions.router.go("/bar")
+              }
+            },
+            "foo"
+          )
+      ],
+      [
+        "/bar",
+        (state, actions) =>
+          h(
+            "div",
+            {
+              onupdate() {
+                expect(location.hash).toBe("#/bar")
+                expect(document.body.innerHTML).toBe("<div>bar</div>")
+                actions.router.go("/baz")
+              }
+            },
+            "bar"
+          )
+      ],
+      [
+        "/baz",
+        (state, actions) =>
+          h(
+            "div",
+            {
+              onupdate() {
+                expect(location.hash).toBe("#/baz")
+                expect(document.body.innerHTML).toBe("<div>baz</div>")
+                done()
+              }
+            },
+            "baz"
+          )
+      ]
+    ],
+    mixins: [router({ hash: true })]
+  })
+})


### PR DESCRIPTION
Abstract out core routing functionality and construct two routers for export at module load:

* The usual `Router`
* `Router.Hash` that uses hash routing.

The interface for both is equivalent and can be used like the following:

```js
const {app, Router} = hyperapp
app({
  mixins: [Router]
})
// or
app({
  mixins: [Router.Hash]
})
```

The rollup file `hyperapp.js` increases by only 238 bytes with this addition:

```txt
-rw-r--r--  1 me  me   3621 Jun 29 11:39 hyperapp.js (before)
-rw-r--r--  1 me  me   3859 Jun 29 11:39 hyperapp.js (after)
```

Prior work:
* hyperapp/hyperapp/pull/79
* ...