### PR TITLE
Refactors router and fixes tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "babel-preset-es2015": "^6.24.1",
-    "hyperapp": "^0.9.3",
+    "hyperapp": "git://github.com/hyperapp/hyperapp.git",
     "jest": "^20.0.4",
     "prettier": "~1.4.1",
     "rollup": "^0.41.6",

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -1,6 +1,8 @@
 import { h, app } from "hyperapp"
 import { Router } from "../src"
 
+window.requestAnimationFrame = setTimeout
+
 const expectHTMLToBe = (body, ...values) =>
   expect(document.body.innerHTML).toBe(
     body.reduce((a, b, i) => a + values[i - 1] + b).replace(/\s{2,}/g, "")
@@ -18,14 +20,13 @@ beforeEach(() => {
 
 test("/", () => {
   app({
-    view: [["/", state => h("div", {}, "foo")]],
+    view: [["/", state => h("div", {
+      oncreate() {
+        expect(document.body.innerHTML).toBe(`<div>foo</div>`)
+      }
+    }, "foo")]],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <div>
-      foo
-    </div>`
 })
 
 test("*", () => {
@@ -60,15 +61,13 @@ test("routes", () => {
   window.location.pathname = "/foo/bar/baz"
 
   app({
-    view: [["/foo/bar/baz", state => h("div", {}, "foo", "bar", "baz")]],
+    view: [["/foo/bar/baz", state => h("div", {
+      oncreate() {
+        expect(document.body.innerHTML).toBe(`<div>foobarbaz</div>`)
+      }
+    }, "foo", "bar", "baz")]],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <div>
-      foobarbaz
-    </div>
-  `
 })
 
 test("route params", () => {
@@ -79,25 +78,24 @@ test("route params", () => {
       [
         "/:foo/:bar/:baz",
         state =>
-          h(
-            "ul",
-            {},
-            Object.keys(state.router.params).map(key =>
-              h("li", {}, `${key}:${state.router.params[key]}`)
-            )
-          )
+          h("ul", {
+            oncreate() {
+              expect(document.body.innerHTML).toBe(`
+                <ul>
+                  <li>foo:be_ep</li>
+                  <li>bar:bOp</li>
+                  <li>baz:b00p</li>
+                </ul>
+              `)
+            }
+          },
+          Object.keys(state.router.route.params).map(key =>
+            h("li", {}, `${key}:${state.router.route.params[key]}`)
+          ))
       ]
     ],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <ul>
-      <li>foo:be_ep</li>
-      <li>bar:bOp</li>
-      <li>baz:b00p</li>
-    </ul>
-  `
 })
 
 test("route params separated by a dash", () => {
@@ -108,25 +106,24 @@ test("route params separated by a dash", () => {
       [
         "/:foo-:bar-:baz",
         state =>
-          h(
-            "ul",
-            {},
-            Object.keys(state.router.params).map(key =>
-              h("li", {}, `${key}:${state.router.params[key]}`)
-            )
-          )
+          h("ul", {
+            oncreate() {
+              expect(document.body.innerHTML).toBe(`
+                <ul>
+                  <li>foo:beep</li>
+                  <li>bar:bop</li>
+                  <li>baz:boop</li>
+                </ul>
+              `)
+            }
+          },
+          Object.keys(state.router.route.params).map(key =>
+            h("li", {}, `${key}:${state.router.route.params[key]}`)
+          ))
       ]
     ],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <ul>
-      <li>foo:beep</li>
-      <li>bar:bop</li>
-      <li>baz:boop</li>
-    </ul>
-  `
 })
 
 test("route params including a dot", () => {
@@ -137,45 +134,50 @@ test("route params including a dot", () => {
       [
         "/:foo/:bar/:baz",
         state =>
-          h(
-            "ul",
-            {},
-            Object.keys(state.router.params).map(key =>
-              h("li", {}, `${key}:${state.router.params[key]}`)
-            )
-          )
+          h("ul", {
+            oncreate() {
+              expect(document.body.innerHTML).toBe(`
+                <ul>
+            			<li>foo:beep</li>
+                  <li>bar:bop.bop</li>
+                  <li>baz:boop</li>
+                </ul>
+              `)
+            }
+          },
+          Object.keys(state.router.route.params).map(key =>
+            h("li", {}, `${key}:${state.router.route.params[key]}`)
+          ))
       ]
     ],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <ul>
-			<li>foo:beep</li>
-      <li>bar:bop.bop</li>
-      <li>baz:boop</li>
-    </ul>
-  `
 })
 
 test("routes with dashes into a single param key", () => {
   window.location.pathname = "/beep-bop-boop"
 
   app({
-    view: [["/:foo", state => h("div", {}, state.router.params.foo)]],
+    view: [["/:foo", state => h("div", {
+      oncreate() {
+        expect(document.body.innerHTML).toBe(`
+          <div>
+            beep-bop-boop
+          </div>
+        `)
+      }
+    }, state.router.route.params.foo)]],
     mixins: [Router]
   })
-
-  expectHTMLToBe`
-    <div>
-      beep-bop-boop
-    </div>
-  `
 })
 
 test("popstate", () => {
   app({
-    view: [["/", state => ""], ["/foo", state => h("div", {}, "foo")]],
+    view: [["/", state => ""], ["/foo", state => h("div", {
+      oncreate() {
+        expect(document.body.innerHTML).toBe(`<div>foo</div>`)
+      }
+    }, "foo")]],
     mixins: [Router]
   })
 
@@ -184,12 +186,6 @@ test("popstate", () => {
   const event = document.createEvent("Event")
   event.initEvent("popstate", true, true)
   window.document.dispatchEvent(event)
-
-  expectHTMLToBe`
-    <div>
-      foo
-    </div>
-  `
 })
 
 test("go", () => {


### PR DESCRIPTION
The router is currently out of sync with the latest release of hyperapp and as it stands as intended or as documented (or at all for that matter) 😅

Although this PR may have a substantial diff.. the router it is now functional again and with almost exactly the behaviours as before. Here are a few things that have changed:

- The router now only accepts `emit` as an argument, like a regular mixin
- The router's state now looks like:
```js
router: {
  url: "/users/luke/27",
  route: { 
    url: "/users/luke/27",
    match: "/users/:id/:age",
    view: (s,a,d) => h('h1', {}, 'Hello!')
    params: {
      id: "luke",
      age: "27"
    }
  }
}
```
- The attribute `router.url` is kept in sync with `location.pathname`
- The attribute `router.route` is updated from within render when router.url !== router.route.url
- the router now uses the `load` event rather than the `loaded` event
- All tests have been updated to account for the new state structure and `app` being async

I _think_ (or hope at least) that this implementation is no more/less performant than the old one but I have not tested it for that really.

There is a breaking change for anyone accessing the routers state directly.. for instance `state.router.match` will now be undefined but can still be accessed through `state.router.route.match`.

The app still emits a `route` event whenever a new route is entered.

That is about all. This is probably going to be my last attempt at this style of router before experimenting further with component based routers as discussed here https://github.com/hyperapp/hyperapp/issues/295