### PR TITLE
Add support for special characters (space, parens, %) within query params

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -47,7 +47,6 @@ function match(pathname, routes) {
   for (var i = 0; i < routes.length && !match; i++) {
     var route = routes[i][0]
     var keys = []
-
     pathname.replace(
       RegExp(
         route === "*"
@@ -55,14 +54,18 @@ function match(pathname, routes) {
           : "^" +
             route.replace(/\//g, "\\/").replace(/:([\w]+)/g, function(_, key) {
               keys.push(key)
-              return "([-\\.%\\w]+)"
+              return "([-\\.%\\w\\(\\)]+)"
             }) +
             "/?$",
         "g"
       ),
       function() {
         for (var j = 1; j < arguments.length - 2; ) {
-          params[keys.shift()] = arguments[j++]
+          var value = arguments[j++]
+          try {
+            value = decodeURI(value)
+          } catch (_) {}
+          params[keys.shift()] = value
         }
         match = route
         index = i

--- a/test/router.test.js
+++ b/test/router.test.js
@@ -199,6 +199,52 @@ test("routes with dashes into a single param key", done => {
   })
 })
 
+test("route params with parentheses", done => {
+  window.location.pathname = "/Parenthesis(rhetoric)"
+  app({
+    view: [
+      [
+        "/:foo",
+        state =>
+          h(
+            "div",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<div>Parenthesis(rhetoric)</div>`)
+                done()
+              }
+            },
+            state.router.params.foo
+          )
+      ]
+    ],
+    mixins: [Router]
+  })
+})
+
+test("route params with uri encoded string", done => {
+  window.location.pathname = "/Batman%20(1989%20film)"
+  app({
+    view: [
+      [
+        "/:foo",
+        state =>
+          h(
+            "div",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<div>Batman (1989 film)</div>`)
+                done()
+              }
+            },
+            state.router.params.foo
+          )
+      ]
+    ],
+    mixins: [Router]
+  })
+})
+
 test("popstate", done => {
   const view = name =>
     h(


### PR DESCRIPTION
I completely understand if there's a preference to not `decodeURI` the route params.

https://github.com/hyperapp/router/compare/master...chiefsmurph:master#diff-15ee858ae5d5aa9b3e2846cfd1c4c466R66

This fixes #10 