### PR TITLE
Link Component Upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "router"
   ],
   "scripts": {
-    "test": "jest --coverage --no-cache",
+    "test": "jest --coverage --no-cache --testURL https://hyperapp.js.org",
     "build": "npm run bundle && npm run minify",
     "bundle": "rollup -i src/index.js -o dist/router.js -f umd -mn Router",
     "minify": "uglifyjs dist/router.js -o dist/router.js --mangle --compress warnings=false --pure-funcs=Object.defineProperty -p relative --source-map dist/router.js.map",

--- a/src/Link.js
+++ b/src/Link.js
@@ -5,12 +5,18 @@ export function Link(props, children) {
   props.to = null
 
   props.onclick = function(e) {
-    if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) return
+    if (
+      e.button !== 0 ||
+      e.metaKey ||
+      e.altKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      props.target === "_blank"
+    )
+      return
 
-    if (e.button === 0) {
-      e.preventDefault()
-      props.go(props.href)
-    }
+    e.preventDefault()
+    props.go(props.href)
   }
 
   return h("a", props, children)

--- a/src/Link.js
+++ b/src/Link.js
@@ -4,9 +4,13 @@ export function Link(props, children) {
   props.href = props.to
   props.to = null
 
-  props.onclick = function(element) {
-    element.preventDefault()
-    props.go(props.href)
+  props.onclick = function(e) {
+    if (e.metaKey || e.altKey || e.ctrlKey || e.shiftKey) return
+
+    if (e.button === 0) {
+      e.preventDefault()
+      props.go(props.href)
+    }
   }
 
   return h("a", props, children)

--- a/src/Link.js
+++ b/src/Link.js
@@ -12,8 +12,9 @@ export function Link(props, children) {
       e.ctrlKey ||
       e.shiftKey ||
       props.target === "_blank"
-    )
+    ) {
       return
+    }
 
     e.preventDefault()
     props.go(props.href)

--- a/src/Link.js
+++ b/src/Link.js
@@ -4,19 +4,19 @@ export function Link(props, children) {
   props.href = props.to
   props.to = null
 
-  props.onclick = function(e) {
+  props.onclick = function(event) {
     if (
-      e.button !== 0 ||
-      e.metaKey ||
-      e.altKey ||
-      e.ctrlKey ||
-      e.shiftKey ||
+      event.button !== 0 ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey ||
       props.target === "_blank"
     ) {
       return
     }
 
-    e.preventDefault()
+    event.preventDefault()
     props.go(props.href)
   }
 

--- a/src/Link.js
+++ b/src/Link.js
@@ -11,7 +11,8 @@ export function Link(props, children) {
       event.altKey ||
       event.ctrlKey ||
       event.shiftKey ||
-      props.target === "_blank"
+      props.target === "_blank" ||
+      event.target.origin !== window.location.origin
     ) {
       return
     }

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -14,6 +14,9 @@ test("Link", done => {
 
   link.data.onclick({
     button: 0, // Left click
+    target: {
+      origin: window.location.origin
+    },
     preventDefault() {} // Noop
   })
 })
@@ -34,6 +37,26 @@ test("Link - Ignore if target ='_blank'", done => {
   expect(mock.mock.calls.length).toBe(0)
   done()
 })
+
+test("Link - Ignore if different origin", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "https://github.com",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    target: {
+      origin: "https://github.com"
+    }
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
 
 test("Link - Only capture unmodified left clicks", done => {
   const mock = jest.fn()

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -29,7 +29,6 @@ test("Link - Ignore if target ='_blank'", done => {
 
   link.data.onclick({
     button: 0, // Left click
-    preventDefault() {} // Noop
   })
 
   expect(mock.mock.calls.length).toBe(0)
@@ -46,31 +45,26 @@ test("Link - Only capture unmodified left clicks", done => {
 
   link.data.onclick({
     button: 1, // Not left click
-    preventDefault() {} // Noop
   })
 
   link.data.onclick({
     button: 0, // Left click
     metaKey: true,
-    preventDefault() {} // Noop
   })
 
   link.data.onclick({
     button: 0, // Left click
     ctrlKey: true,
-    preventDefault() {} // Noop
   })
 
   link.data.onclick({
     button: 0, // Left click
     altKey: true,
-    preventDefault() {} // Noop
   })
 
   link.data.onclick({
     button: 0, // Left click
     shiftKey: true,
-    preventDefault() {} // Noop
   })
 
   expect(mock.mock.calls.length).toBe(0)

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -18,7 +18,25 @@ test("Link", done => {
   })
 })
 
-test("Link - Ignore middle click", done => {
+test("Link - Ignore if target ='_blank'", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock,
+    target: "_blank"
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
+test("Link - Only capture unmodified left clicks", done => {
   const mock = jest.fn()
 
   const link = h(Link, {
@@ -31,34 +49,10 @@ test("Link - Ignore middle click", done => {
     preventDefault() {} // Noop
   })
 
-  expect(mock.mock.calls.length).toBe(0)
-  done()
-})
-
-test("Link - Ignore if Meta key", done => {
-  const mock = jest.fn()
-
-  const link = h(Link, {
-    to: "foo",
-    go: mock
-  })
-
   link.data.onclick({
     button: 0, // Left click
     metaKey: true,
     preventDefault() {} // Noop
-  })
-
-  expect(mock.mock.calls.length).toBe(0)
-  done()
-})
-
-test("Link - Ignore if CTRL key", done => {
-  const mock = jest.fn()
-
-  const link = h(Link, {
-    to: "foo",
-    go: mock
   })
 
   link.data.onclick({
@@ -67,34 +61,10 @@ test("Link - Ignore if CTRL key", done => {
     preventDefault() {} // Noop
   })
 
-  expect(mock.mock.calls.length).toBe(0)
-  done()
-})
-
-test("Link - Ignore if ALT key", done => {
-  const mock = jest.fn()
-
-  const link = h(Link, {
-    to: "foo",
-    go: mock
-  })
-
   link.data.onclick({
     button: 0, // Left click
     altKey: true,
     preventDefault() {} // Noop
-  })
-
-  expect(mock.mock.calls.length).toBe(0)
-  done()
-})
-
-test("Link - Ignore if Shift key", done => {
-  const mock = jest.fn()
-
-  const link = h(Link, {
-    to: "foo",
-    go: mock
   })
 
   link.data.onclick({
@@ -106,4 +76,3 @@ test("Link - Ignore if Shift key", done => {
   expect(mock.mock.calls.length).toBe(0)
   done()
 })
-

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -1,7 +1,7 @@
 import { h } from "hyperapp"
 import { Link } from "../src"
 
-test("/", done => {
+test("Link", done => {
   const link = h(Link, {
     to: "foo",
     go(path) {
@@ -13,6 +13,97 @@ test("/", done => {
   expect(link.data.href).toBe("foo")
 
   link.data.onclick({
+    button: 0, // Left click
     preventDefault() {} // Noop
   })
 })
+
+test("Link - Ignore middle click", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 1, // Not left click
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
+test("Link - Ignore if Meta key", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    metaKey: true,
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
+test("Link - Ignore if CTRL key", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    ctrlKey: true,
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
+test("Link - Ignore if ALT key", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    altKey: true,
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+
+test("Link - Ignore if Shift key", done => {
+  const mock = jest.fn()
+
+  const link = h(Link, {
+    to: "foo",
+    go: mock
+  })
+
+  link.data.onclick({
+    button: 0, // Left click
+    shiftKey: true,
+    preventDefault() {} // Noop
+  })
+
+  expect(mock.mock.calls.length).toBe(0)
+  done()
+})
+


### PR DESCRIPTION
**Description**
Added some common checks to the <Link> component which I found in other routers.

To ensure default browser behaviors work, we should not navigate if:
 - meta, ctrl, alt, shift keys are pressed
 - non-primary mouse button/enter key
 - link target = "_blank"

**Tests**
Maintained 100% coverage.  Used jest's mock functions.

**Bundle size**
Added ~50 bytes gzipped to the build.

**Simple example:**
https://www.webpackbin.com/bins/-Ks531DrGloAvqjQO26i

**Other potential enhancements**
Some other libraries, like react-router, allow user-defined `onclick` handlers on their link component.  They save a reference to the function and call it in the "final" click handler, then check for `e.defaultPrevented`.   Do you want this feature also?