### PR TITLE
Link should check event.currentTarget

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -12,7 +12,7 @@ export function Link(props, children) {
       event.ctrlKey ||
       event.shiftKey ||
       props.target === "_blank" ||
-      event.target.origin !== window.location.origin
+      event.currentTarget.origin !== window.location.origin
     ) {
       return
     }

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -14,7 +14,7 @@ test("Link", done => {
 
   link.data.onclick({
     button: 0, // Left click
-    target: {
+    currentTarget: {
       origin: window.location.origin
     },
     preventDefault() {} // Noop
@@ -48,7 +48,7 @@ test("Link - Ignore if different origin", done => {
 
   link.data.onclick({
     button: 0, // Left click
-    target: {
+    currentTarget: {
       origin: "https://github.com"
     }
   })


### PR DESCRIPTION
In the <Link> component's origin check, it was checking `event.target.origin`.

While using the component, I quickly discovered it doesn't work correctly if you give the Link any non-text children.

For example:
```js
        Link({to: '/', go: actions.router.go },[
          h('img', {class: 'logo', src: '/static/logo.svg'})
        ]),
```
In this code, when you click the image link, the `event.target` is actually the `img` tag, since you clicked it.  `event.currentTarget` should be used instead, since it always references the element which has the event listener.

Reference docs:  https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget