### PR TITLE
Revamp API: selected <Route /> and <Link /> as "view components".

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,23 @@
 import { router, Link } from "@hyperapp/router"
 
 app({
-  view: [
+  view: (state, actions, { Route }) => <Route />,
+  mixins: [router([
     [
       "/",
-      (state, actions) =>
-        <Link to="/test" go={actions.router.go}>
+      (state, actions, { Link }) =>
+        <Link to="/test">
           Test
         </Link>
     ],
     [
       "/test",
-      (state, actions) =>
-        <Link to="/" go={actions.router.go}>
+      (state, actions, { Link }) =>
+        <Link to="/">
           Back
         </Link>
     ]
-  ],
-  mixins: [router()]
+  ])]
 })
 ```
 

--- a/src/router.js
+++ b/src/router.js
@@ -1,4 +1,6 @@
-export function router(options) {
+import { Link } from "./Link"
+
+export function router(routes) {
   return function(emit) {
     return {
       state: {
@@ -28,13 +30,29 @@ export function router(options) {
           })
         },
         render: function(state, actions, view) {
-          return view[
-            (state.router.index >= 0
-              ? state
-              : actions.router.set(
-                  emit("route", match(location.pathname, view))
-                )).router.index
-          ][1]
+          return function(state, actions, widgets) {
+            widgets = widgets || {}
+
+            widgets.Link = function(props, children) {
+              props.go = actions.router.go
+              return Link(props, children)
+            }
+
+            var route =
+              routes[
+                (state.router.index >= 0
+                  ? state
+                  : actions.router.set(
+                      emit("route", match(location.pathname, routes))
+                    )).router.index
+              ][1]
+
+            widgets.Route = function(props, children) {
+              return route(state, actions, widgets)
+            }
+
+            return view(state, actions, widgets)
+          }
         }
       }
     }


### PR DESCRIPTION
## What's this?

Change API as follows:

1) Declare routes by passing them to the `router(..)` mixin, not overloading the view function! 🎉 

```js
mixins: [
  router([ 
    [string, View], 
    [string, View], 
    ... 
  ])
]
```

2) Share matched route with your view as a _view component_. We can define view components as a regular component that is "pre-wired" to your state/actions, etc., and then passed to the view function call as the third argument.

```js
view(state, actions, { Route }) {
  return (
    <main>
      <MyHeader />
        ...
      <Route />
        ...
      <MyFotter />
    </main>
  )
}
```

3) Also share `<Link>` component pre-wired to `actions.router.go` as a view component.

## Example

```jsx
import { h, app } from "hyperapp"
import { router } from "../.."

app({
  view: (state, actions, { Route }) => <Route />,
  mixins: [
    router([
      [
        "/", (state, actions, { Link }) =>
          <Link to="/test">
            Test
          </Link>
      ],
      [
        "/test", (state, actions, { Link }) =>
          <Link to="/">
            Back
          </Link>
      ]
    ])
  ]
})
```

See the [same example](https://github.com/hyperapp/router#hyperapprouter) on the readme to compare.

## Discussion

How do we go about sharing, distributing and "reasoning" about (pre-wired) view components and their simply exported counterparts?

You could still import `Link` from this module and use it as described in the current docs, but if we are going to give it to you pre-wired in the view, why should index.js export Link? What if we don't export Link?

One more thing. What should be the convention for passing "pre-wired" components to the view? 




