### PR TITLE
Allow Switch component without h

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,3 +1,5 @@
 export function Switch(props, children) {
-  return children[0]
+  var i = 0
+  while (!children[i] && i < children.length) i++
+  return children[i]
 }

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -1,13 +1,13 @@
 import { Switch } from "../src/Switch"
 
-test('Switch returns only the first truthy child', () => {
-  const expected = 'truthy value'
-  const children = [0, null, expected, false, 'other']
+test("Switch returns only the first truthy child", () => {
+  const expected = "truthy value"
+  const children = [0, null, expected, false, "other"]
   expect(Switch(null, children)).toBe(expected)
 })
 
-test('Switch returns falsy when all children falsy', () => {
-  const children = [0, '', false, null]
+test("Switch returns falsy when all children falsy", () => {
+  const children = [0, "", false, null]
   expect(Switch(null, children)).toBeFalsy()
 })
 

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -1,0 +1,13 @@
+import { Switch } from "../src/Switch"
+
+test('Switch returns only the first truthy child', () => {
+  const expected = 'truthy value'
+  const children = [0, null, expected, false, 'other']
+  expect(Switch(null, children)).toBe(expected)
+})
+
+test('Switch returns falsy when all children falsy', () => {
+  const children = [0, '', false, null]
+  expect(Switch(null, children)).toBeFalsy()
+})
+


### PR DESCRIPTION
Switch should return only the first match of its children, i e only the first of non-falsy children.

Previous implemetation relied on calling as: `h(Switch, null, [....])` because h filters out falsy children. 

This implementation does not assume all children are truthy, allowing you to call it simply as: `Switch(null, [...])`