### PR TITLE
Use of Lazy Components

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ Then call `subscribe` to listen to location change events.
 const unsubscribe = location.subscribe(main.location)
 ```
 
+### State First
+
+By default, for convenience, the router use the `window.location` property as source of truth.
+If you want to ensure the router to use the state as only source of truth : you are responsible of wiring the `location` slice to your `state` and `actions`.
+Then call `subscribe` to listen to location change events and reflect it into the `state`.
+
 ## Components
 
 ### Route

--- a/package.json
+++ b/package.json
@@ -35,11 +35,11 @@
   },
   "devDependencies": {
     "babel-preset-env": "^1.6.1",
-    "hyperapp": "0.18.0",
-    "jest": "^21.2.1",
+    "hyperapp": "^1.2.1",
+    "jest": "^22.4.3",
     "prettier": "^1.9.2",
-    "rollup": "^0.52.0",
-    "uglify-js": "3.2.2"
+    "rollup": "^0.57.1",
+    "uglify-js": "^3.3.16"
   },
   "peerDependencies": {
     "hyperapp": "0.18.0"

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,28 +1,30 @@
 import { h } from "hyperapp"
 
 export function Link(props, children) {
-  var to = props.to
-  var location = props.location || window.location
+  return function(state, actions) {
+    var to = props.to
+    var location = state.location || window.location
 
-  props.href = to
-  props.onclick = function(e) {
-    if (
-      e.button !== 0 ||
-      e.altKey ||
-      e.metaKey ||
-      e.ctrlKey ||
-      e.shiftKey ||
-      props.target === "_blank" ||
-      e.currentTarget.origin !== location.origin
-    ) {
-    } else {
-      e.preventDefault()
+    props.href = to
+    props.onclick = function(e) {
+      if (
+        e.button !== 0 ||
+        e.altKey ||
+        e.metaKey ||
+        e.ctrlKey ||
+        e.shiftKey ||
+        props.target === "_blank" ||
+        location.origin && e.currentTarget.origin !== location.origin
+      ) {
+      } else {
+        e.preventDefault()
 
-      if (to !== location.pathname) {
-        history.pushState(location.pathname, "", to)
+        if (to !== location.pathname) {
+          history.pushState(location.pathname, "", to)
+        }
       }
     }
-  }
 
-  return h("a", props, children)
+    return h("a", props, children)
+  }
 }

--- a/src/Link.js
+++ b/src/Link.js
@@ -14,7 +14,7 @@ export function Link(props, children) {
         e.ctrlKey ||
         e.shiftKey ||
         props.target === "_blank" ||
-        location.origin && e.currentTarget.origin !== location.origin
+        (location.origin && e.currentTarget.origin !== location.origin)
       ) {
       } else {
         e.preventDefault()

--- a/src/Redirect.js
+++ b/src/Redirect.js
@@ -1,4 +1,6 @@
 export function Redirect(props) {
-  var location = props.location || window.location
-  history.replaceState(props.from || location.pathname, "", props.to)
+  return function(state, actions) {
+    var location = state.location || window.location
+    history.replaceState(props.from || location.pathname, "", props.to)
+  }
 }

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,16 +1,18 @@
 import { parseRoute } from "./parseRoute"
 
 export function Route(props) {
-  var location = props.location || window.location
-  var match = parseRoute(props.path, location.pathname, {
-    exact: !props.parent
-  })
-
-  return (
-    match &&
-    props.render({
-      match: match,
-      location: location
+  return function (state, actions) {
+    var location = state.location || window.location
+    var match = parseRoute(props.path, location.pathname, {
+      exact: !props.parent
     })
-  )
+
+    return (
+      match &&
+      props.render({
+        match: match,
+        location: location
+      })
+    )
+  }
 }

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,7 +1,7 @@
 import { parseRoute } from "./parseRoute"
 
 export function Route(props) {
-  return function (state, actions) {
+  return function(state, actions) {
     var location = state.location || window.location
     var match = parseRoute(props.path, location.pathname, {
       exact: !props.parent

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,7 @@
 import { h, app } from "hyperapp"
 import { Route, location } from "../src"
 
-test("router", done => {
+test("Router", done => {
   const state = {
     location: location.state
   }
@@ -35,4 +35,33 @@ test("router", done => {
   const unsubscribe = location.subscribe(main.location)
 
   main.location.go("/test")
+})
+
+test("Router without state/actions module", done => {
+  const state = {}
+
+  const actions = {}
+
+  const main = app(
+    state,
+    actions,
+    (state, actions) =>
+      h(Route, {
+        path: "/test",
+        render: () =>
+          h(
+            "h1",
+            {
+              oncreate() {
+                expect(document.body.innerHTML).toBe(`<h1>Hello</h1>`)
+                done()
+              }
+            },
+            "Hello"
+          )
+      }),
+    document.body
+  )
+
+  history.pushState(null, "", "/test")
 })

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -7,7 +7,7 @@ const fakeEvent = {
   preventDefault: () => {}
 }
 
-test("redirect", done => {
+test("Link", done => {
   const state = {
     location: location.state
   }
@@ -26,7 +26,7 @@ test("redirect", done => {
           render: () => {
             h(Link, {
               to: "/done"
-            }).props.onclick(fakeEvent)
+            })(state, actions).attributes.onclick(fakeEvent)
           }
         }),
         h(Route, {
@@ -53,4 +53,45 @@ test("redirect", done => {
   const unsubscribe = location.subscribe(main.location)
 
   main.location.go("/test")
+})
+
+test("Link without state/actions module", done => {
+  const state = {}
+
+  const actions = {}
+
+  const main = app(
+    state,
+    actions,
+    (state, actions) =>
+      h("div", {}, [
+        h(Route, {
+          path: "/test",
+          render: () => {
+            h(Link, {
+              to: "/done"
+            })(state, actions).attributes.onclick(fakeEvent)
+          }
+        }),
+        h(Route, {
+          path: "/done",
+          render: () =>
+            h(
+              "h1",
+              {
+                oncreate() {
+                  expect(document.body.innerHTML).toBe(
+                    `<div><h1>Hello</h1></div>`
+                  )
+                  done()
+                }
+              },
+              "Hello"
+            )
+        })
+      ]),
+    document.body
+  )
+
+  history.pushState(null, "", "/test")
 })

--- a/test/redirect.test.js
+++ b/test/redirect.test.js
@@ -1,7 +1,7 @@
 import { h, app } from "hyperapp"
 import { Route, Redirect, location } from "../src"
 
-test("redirect", done => {
+test("Redirect", done => {
   const state = {
     location: location.state
   }
@@ -46,4 +46,44 @@ test("redirect", done => {
   const unsubscribe = location.subscribe(main.location)
 
   main.location.go("/test")
+})
+
+test("Redirect without state/actions module", done => {
+  const state = {}
+
+  const actions = {}
+
+  const main = app(
+    state,
+    actions,
+    (state, actions) =>
+      h("div", {}, [
+        h(Route, {
+          path: "/test",
+          render: () =>
+            h(Redirect, {
+              to: "/done"
+            })
+        }),
+        h(Route, {
+          path: "/done",
+          render: () =>
+            h(
+              "h1",
+              {
+                oncreate() {
+                  expect(document.body.innerHTML).toBe(
+                    `<div><h1>Hello</h1></div>`
+                  )
+                  done()
+                }
+              },
+              "Hello"
+            )
+        })
+      ]),
+    document.body
+  )
+
+  history.pushState(null, "", "/test")
 })


### PR DESCRIPTION
This PR replace #56 and solve #52, #47 and maybe #53 

No change on the API surface.
Only the previously undocumented `location` property disappear.

Like the old behavior (without the `location` property), the router use the `window.location` property as source of truth.

In other word, you are able to use the router without using the `location` slice wired to the `state` and `actions` and the use of `subscribe`.

**tl;dr** If you are using the router this PR will add state first routing without no need to change your code.