### PR TITLE
Don't pass through "to" and "location" attributes from <Link> to <a>

### DIFF
--- a/src/Link.js
+++ b/src/Link.js
@@ -3,6 +3,8 @@ import { h } from "hyperapp"
 export function Link(props, children) {
   var to = props.to
   var location = props.location || window.location
+  delete props.to
+  delete props.location
 
   props.href = to
   props.onclick = function(e) {

--- a/test/link.test.js
+++ b/test/link.test.js
@@ -54,3 +54,11 @@ test("redirect", done => {
 
   main.location.go("/test")
 })
+
+test("pass through attributes", () => {
+  const vnode = h(Link, { to: "/path", pass: "through", location })
+  expect(vnode.props.to).toBeUndefined()
+  expect(vnode.props.location).toBeUndefined()
+  expect(vnode.props.href).toEqual("/path")
+  expect(vnode.props.pass).toEqual("through")
+})


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/96157/37782095-69ef188c-2e35-11e8-929c-adca1bf622f5.png)

### Note
There is a small breaking change:

```js
// No longer works
const sharedLinkProps = { to: "/path" }

h(Link, sharedLinkProps) // sharedLinkProps.to is deleted here
h(Link, sharedLinkProps)
h(Link, sharedLinkProps)
```