### PR TITLE
Fix Switch to handle lazy components

### DIFF
--- a/src/Switch.js
+++ b/src/Switch.js
@@ -1,5 +1,12 @@
 export function Switch(props, children) {
-  var i = 0
-  while (!children[i] && i < children.length) i++
-  return children[i]
+  return function(state, actions) {
+    var child,
+      i = 0
+    while (
+      !(child = children[i] && children[i](state, actions)) &&
+      i < children.length
+    )
+      i++
+    return child
+  }
 }

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -1,0 +1,48 @@
+import { Route } from "../src/Route"
+
+test("Route is a lazy component", () => {
+  expect(Route(null, [])).toBeInstanceOf(Function)
+})
+
+test("Route returns falsy if it doesn't match to current location", () => {
+  const state = { location: { pathname: "/" } }
+  const actions = {}
+  const render = jest.fn()
+  expect(Route({ path: "/users", render }, [])(state, actions)).toBeFalsy()
+  expect(render).not.toBeCalled()
+})
+
+test("Route returns result of render prop if it exactly matches to current location", () => {
+  expect.assertions(3)
+  const state = { location: { pathname: "/users" } }
+  const actions = {}
+  const render = jest.fn(({ match }) => {
+    expect(match.isExact).toBe(true)
+    return "result"
+  })
+  expect(Route({ path: "/users", render }, [])(state, actions)).toEqual(
+    "result"
+  )
+  expect(render).toBeCalled()
+})
+
+test("Route returns result of render prop if it matches to current location", () => {
+  expect.assertions(4)
+  const state = { location: { pathname: "/users/1" } }
+  const actions = {}
+  const render = jest.fn(({ match }) => {
+    expect(match.isExact).toBe(false)
+    expect(match.params).toEqual({ id: "1" })
+    return "result"
+  })
+  expect(Route({ path: "/users/:id", render }, [])(state, actions)).toEqual(
+    "result"
+  )
+  expect(render).toBeCalled()
+})
+
+test("Route without path prop matches to every location", () => {
+  const render = () => true
+  expect(Route({ render }, [])({ location: { pathname: "/" } })).toBe(true)
+  expect(Route({ render }, [])({ location: { pathname: "/users" } })).toBe(true)
+})

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -2,11 +2,15 @@ import { Switch } from "../src/Switch"
 
 test("Switch returns only the first truthy child", () => {
   const expected = "truthy value"
-  const children = [0, null, expected, false, "other"]
-  expect(Switch(null, children)).toBe(expected)
+  const children = [0, null, expected, false, "other"].map(child => () => child)
+  expect(Switch(null, children)()).toBe(expected)
 })
 
 test("Switch returns falsy when all children falsy", () => {
-  const children = [0, "", false, null]
-  expect(Switch(null, children)).toBeFalsy()
+  const children = [0, "", false, null].map(child => () => child)
+  expect(Switch(null, children)()).toBeFalsy()
+})
+
+test("Switch returns falsy when children is empty", () => {
+  expect(Switch(null, [])()).toBeFalsy()
 })

--- a/test/switch.test.js
+++ b/test/switch.test.js
@@ -1,16 +1,43 @@
 import { Switch } from "../src/Switch"
 
+test("Switch expects children are implemented as lazy components", () => {
+  const state = new Object()
+  const actions = new Object()
+  const child = jest.fn()
+  Switch(null, [child])(state, actions)
+  expect(child.mock.calls.length).toBe(1)
+  expect(child).toBeCalledWith(state, actions)
+})
+
 test("Switch returns only the first truthy child", () => {
-  const expected = "truthy value"
-  const children = [0, null, expected, false, "other"].map(child => () => child)
-  expect(Switch(null, children)()).toBe(expected)
+  const state = new Object()
+  const actions = new Object()
+  const children = [
+    jest.fn(() => 0),
+    jest.fn(() => null),
+    jest.fn(() => "first truthy value"),
+    jest.fn(() => "another truthy")
+  ]
+  expect(Switch(null, children)(state, actions)).toEqual("first truthy value")
+  expect(children[0]).toBeCalledWith(state, actions)
+  expect(children[1]).toBeCalledWith(state, actions)
+  expect(children[2]).toBeCalledWith(state, actions)
+  expect(children[3]).not.toBeCalled()
 })
 
 test("Switch returns falsy when all children falsy", () => {
-  const children = [0, "", false, null].map(child => () => child)
-  expect(Switch(null, children)()).toBeFalsy()
+  const state = new Object()
+  const actions = new Object()
+  const children = [
+    jest.fn(() => 0),
+    jest.fn(() => ""),
+    jest.fn(() => false),
+    jest.fn(() => null)
+  ]
+  expect(Switch(null, children)(state, actions)).toBeFalsy()
+  children.forEach(child => expect(child).toBeCalledWith(state, actions))
 })
 
 test("Switch returns falsy when children is empty", () => {
-  expect(Switch(null, [])()).toBeFalsy()
+  expect(Switch(null, [])({}, {})).toBeFalsy()
 })


### PR DESCRIPTION
Because `<Route>` is implemented as lazy component, `<Switch>`'s children argument is an array of functions. 