### PR TITLE
Issue 54, basic SSR

### DIFF
--- a/src/location.js
+++ b/src/location.js
@@ -16,12 +16,16 @@ function wrapHistory(keys) {
 
 export var location = {
   state: {
-    pathname: window.location.pathname,
-    previous: window.location.pathname
+    pathname: typeof window === 'undefined' ? '' : window.location.pathname,
+    previous: typeof window === 'undefined' ? '' : window.location.pathname
   },
   actions: {
     go: function(pathname) {
-      history.pushState(null, "", pathname)
+      return function(state, actions) {
+        typeof history === 'undefined'
+          ? actions.set({ pathname: pathname, previous: state.pathname })
+          : history.pushState(null, "", pathname)
+      }
     },
     set: function(data) {
       return data


### PR DESCRIPTION
Add a simple check for `undefined` to the window and history objects to avoid errors when using `@hyperapp/router` on the server side in combination with `@hyperapp/render`.

Assuming the `subscribe` method is only used in the client side.