### PR TITLE
Remove render prop in favor of render child

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,15 +246,15 @@ const NoMatchExample = (
     <Route path="/">
       <Home/>
     </Route>
-    <Route path="/old-match"/>
+    <Route path="/old-match">
       {() => <Redirect from="/old-match" to="/will-match" />}
     </Route>
     <Route path="/will-match">
       <WillMatch/>
-    </Router>
+    </Route>
     <Route>
       <NoMatch/>
-    </Router>
+    </Route>
   </Switch>
 )
 ```

--- a/README.md
+++ b/README.md
@@ -58,9 +58,15 @@ const view = state => (
 
     <hr />
 
-    <Route path="/" render={Home} />
-    <Route path="/about" render={About} />
-    <Route parent path="/topics" render={TopicsView} />
+    <Route path="/">
+      <Home/>
+    </Route>
+    <Route path="/about">
+      <About/>
+    </Route>
+    <Route parent path="/topics">
+      <TopicsView/>
+    </Route>
   </div>
 )
 
@@ -99,7 +105,7 @@ const actions = {
 const main = app(
   state,
   actions,
-  (state, actions) => <Route render={() => <h1>Hello!</h1>} />,
+  (state, actions) => <Route>{() => <h1>Hello!</h1>}</Route>,
   document.body
 )
 ```
@@ -117,9 +123,15 @@ const unsubscribe = location.subscribe(main.location)
 Render a component when the given path matches the current [window location](https://developer.mozilla.org/en-US/docs/Web/API/Location). A route without a path is always a match. Routes can have nested routes.
 
 ```jsx
-<Route path="/" render={Home} />
-<Route path="/about" render={About} />
-<Route parent path="/topics" render={TopicsView} />
+<Route path="/">
+  <Home/>
+</Route>
+<Route path="/about">
+  <About/>
+</Route>
+<Route parent path="/topics">
+  <TopicsView/>
+</Route>
 ```
 
 #### parent
@@ -130,13 +142,9 @@ The route contains child routes.
 
 The path to match against the current location.
 
-#### render
+### Render Child function
 
-The component to render when there is a match.
-
-### Render Props
-
-Rendered components are passed the following props.
+Child rendered components are passed the following props.
 
 ```jsx
 const RouteInfo = ({ location, match }) => (
@@ -235,13 +243,18 @@ Use the Switch component when you want to ensure only one out of several routes 
 ```jsx
 const NoMatchExample = (
   <Switch>
-    <Route path="/" render={Home} />
-    <Route
-      path="/old-match"
-      render={() => <Redirect from="/old-match" to="/will-match" />}
-    />
-    <Route path="/will-match" render={WillMatch} />
-    <Route render={NoMatch} />
+    <Route path="/">
+      <Home/>
+    </Route>
+    <Route path="/old-match"/>
+      {() => <Redirect from="/old-match" to="/will-match" />}
+    </Route>
+    <Route path="/will-match">
+      <WillMatch/>
+    </Router>
+    <Route>
+      <NoMatch/>
+    </Router>
   </Switch>
 )
 ```

--- a/src/Route.js
+++ b/src/Route.js
@@ -1,6 +1,6 @@
 import { parseRoute } from "./parseRoute"
 
-export function Route(props) {
+export function Route(props, children) {
   return function(state, actions) {
     var location = state.location
     var match = parseRoute(props.path, location.pathname, {
@@ -9,7 +9,7 @@ export function Route(props) {
 
     return (
       match &&
-      props.render({
+      children[0]({
         match: match,
         location: location
       })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -21,7 +21,7 @@ afterEach(() => {
 
 test("Transition by location.go()", async done => {
   const spy = jest.fn()
-  const view = () => <Route path="/test" render={spy} />
+  const view = () => <Route path="/test">{spy}</Route>
   const main = app(state, actions, view, document.body)
   unsubscribe = location.subscribe(main.location)
   await wait(0)
@@ -37,7 +37,7 @@ test("Transition by clicking Link", async done => {
   const view = () => (
     <div>
       <Link to="/test" />
-      <Route path="/test" render={spy} />
+      <Route path="/test">{spy}</Route>
     </div>
   )
   const main = app(state, actions, view, document.body)
@@ -60,7 +60,7 @@ test('Click Link with target="_blank"', async done => {
   const view = () => (
     <div>
       <Link to="/test" target="_blank" />
-      <Route path="/test" render={spy} />
+      <Route path="/test">{spy}</Route>
     </div>
   )
   const main = app(state, actions, view, document.body)
@@ -90,7 +90,7 @@ test("Transition by clicking Link including non alphanumeric characters", async 
   const view = () => (
     <div>
       <Link to="/test/café" />
-      <Route path="/test/:id" render={spy} />
+      <Route path="/test/:id">{spy}</Route>
     </div>
   )
   const main = app(state, actions, view, document.body)
@@ -109,8 +109,8 @@ test("Transition by rendering Redirect", async done => {
   const spy = jest.fn()
   const view = () => (
     <div>
-      <Route path="/test" render={() => <Redirect to="/somewhere" />} />
-      <Route path="/somewhere" render={spy} />
+      <Route path="/test">{() => <Redirect to="/somewhere" />}</Route>
+      <Route path="/somewhere">{spy}</Route>
     </div>
   )
   const main = app(state, actions, view, document.body)

--- a/test/route.test.js
+++ b/test/route.test.js
@@ -8,7 +8,7 @@ test("Route returns falsy if it doesn't match to current location", () => {
   const state = { location: { pathname: "/articles" } }
   const actions = {}
   const render = jest.fn()
-  expect(Route({ path: "/users", render }, [])(state, actions)).toBeFalsy()
+  expect(Route({ path: "/users" }, [render])(state, actions)).toBeFalsy()
   expect(render).not.toBeCalled()
 })
 
@@ -20,7 +20,7 @@ test("Route returns result of render prop if it exactly matches to current locat
     expect(match.isExact).toBe(true)
     return "result"
   })
-  expect(Route({ path: "/users", render }, [])(state, actions)).toEqual(
+  expect(Route({ path: "/users" }, [render])(state, actions)).toEqual(
     "result"
   )
   expect(render).toBeCalled()
@@ -35,7 +35,7 @@ test("Route returns result of render prop if it matches to current location", ()
     expect(match.params).toEqual({ id: "1" })
     return "result"
   })
-  expect(Route({ path: "/users/:id", render }, [])(state, actions)).toEqual(
+  expect(Route({ path: "/users/:id" }, [render])(state, actions)).toEqual(
     "result"
   )
   expect(render).toBeCalled()
@@ -43,8 +43,8 @@ test("Route returns result of render prop if it matches to current location", ()
 
 test("Route without path prop matches to every location", () => {
   const render = () => true
-  expect(Route({ render }, [])({ location: { pathname: "/" } })).toBe(true)
-  expect(Route({ render }, [])({ location: { pathname: "/users" } })).toBe(true)
+  expect(Route({}, [render])({ location: { pathname: "/" } })).toBe(true)
+  expect(Route({}, [render])({ location: { pathname: "/users" } })).toBe(true)
 })
 
 test("Route decodes encoded URI", () => {
@@ -54,7 +54,7 @@ test("Route decodes encoded URI", () => {
   const render = ({ match }) => {
     expect(match.params).toEqual({ foo: "café", bar: "baz" })
   }
-  Route({ path: "/foo/:foo/bar/:bar", render }, [])(state, actions)
+  Route({ path: "/foo/:foo/bar/:bar" }, [render])(state, actions)
 })
 
 test("Route ignores url params containing invalid character sequences", () => {
@@ -67,6 +67,6 @@ test("Route ignores url params containing invalid character sequences", () => {
     expect(match.params).toEqual({ foo: invalid, bar: "baz" })
   }
   expect(() =>
-    Route({ path: "/foo/:foo/bar/:bar", render }, [])(state, actions)
+    Route({ path: "/foo/:foo/bar/:bar" }, [render])(state, actions)
   ).not.toThrowError()
 })


### PR DESCRIPTION
Now we have Lazy Components we can let user be responsible of using them to prevent computation issues.

Instead of using a render property, this PR add the ability to define route in a more composable way. Only the first child is used as rendered route.

---
```jsx
<Route path="/">
  <Home/>
</Route>
```
```jsx
Route({ path: "/" }, [Home])
```
---
```jsx
<Route path="/old-match">
  {() => <Redirect from="/old-match" to="/will-match" />}
</Route>
```
```jsx
Route({ path: "/old-match"}, [
  () => Redirect({ from: "/old-match", to: "/will-match" })
])
```