### PR TITLE
Only way found to fix nasty erros on TS build.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ interface LinkProps {
   to: string;
   location?: Location;
 }
-export function Link(props: LinkProps): VNode<LinkProps>;
+export function Link(props: LinkProps): VNode<LinkProps> | any;
 
 /** Route */
 interface Match<P> {
@@ -28,7 +28,7 @@ interface RouteProps<P> {
 
 export function Route<P>(
   props: RouteProps<P>
-): VNode<RenderProps<P>> | void;
+): VNode<RenderProps<P>> | any;
 
 /**Switch */
 export function Switch<P>(


### PR DESCRIPTION
- Reason for `export function Link(props: LinkProps): VNode<LinkProps> | any;` change request:
```
    TS2605: JSX element type 'void | VNode<LinkProps>' is not a constructor function for JSX elements.
  Type 'void' is not assignable to type 'Element | null'.
```

- Reason for `export function Route<P>(  props: RouteProps<P>): VNode<RenderProps<P>> | any;` change request:
```
    TS2605: JSX element type 'VNode<RenderProps<{}>>' is not a constructor function for JSX elements.
  Type 'VNode<RenderProps<{}>>' is missing the following properties from type 'Element': type, props
```

Let me know if you guys find exactly which type we should declare.